### PR TITLE
Fix: Use endpoint to cache the schema

### DIFF
--- a/src/Prisma.ts
+++ b/src/Prisma.ts
@@ -44,7 +44,7 @@ export class Prisma extends Binding {
     const token = secret ? sign({}, secret!) : undefined
     const link = makePrismaLink({ endpoint: endpoint!, token, debug })
 
-    const remoteSchema = getCachedRemoteSchema(typeDefs, sharedLink)
+    const remoteSchema = getCachedRemoteSchema(typeDefs, sharedLink, endpoint)
 
     const before = () => {
       sharedLink.setInnerLink(link)

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -4,7 +4,7 @@ import { SharedLink } from './SharedLink'
 import { makeRemoteExecutableSchema } from 'graphql-tools'
 
 const typeDefsCache: { [schemaPath: string]: string } = {}
-const remoteSchemaCache: { [typeDefs: string]: GraphQLSchema } = {}
+const remoteSchemaCache: { [endpoint: string]: GraphQLSchema } = {}
 
 export function getCachedTypeDefs(schemaPath: string): string {
   if (typeDefsCache[schemaPath]) {
@@ -20,9 +20,10 @@ export function getCachedTypeDefs(schemaPath: string): string {
 export function getCachedRemoteSchema(
   typeDefs: string,
   link: SharedLink,
+  endpoint: string,
 ): GraphQLSchema {
-  if (remoteSchemaCache[typeDefs]) {
-    return remoteSchemaCache[typeDefs]
+  if (remoteSchemaCache[endpoint]) {
+    return remoteSchemaCache[endpoint]
   }
 
   const remoteSchema = makeRemoteExecutableSchema({
@@ -30,7 +31,7 @@ export function getCachedRemoteSchema(
     link: link as any,
     schema: typeDefs,
   })
-  remoteSchemaCache[typeDefs] = remoteSchema
+  remoteSchemaCache[endpoint] = remoteSchema
 
   return remoteSchema
 }


### PR DESCRIPTION
As explained in the issue #81 :

If we have two distinct services using the same typeDefs (for example, in a multi-tenant application), then `prisma-binding` was caching the typeDefs (and the link) in a map with the `typeDefs` as a key.
This, means that requests trying to reach the second service would go to the first service.

In order to fix this issue, I suggest that we use the `endpoint` as the key of the cache map.