### PR TITLE
src: Add option to disable prisma-binding schema cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "apollo-link-ws": "1.0.12",
     "cross-fetch": "3.0.0",
     "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0",
-    "graphql-binding": "2.4.1",
+    "graphql-binding": "2.5.0",
     "graphql-import": "0.7.1",
     "graphql-tools": "4.0.3",
     "http-link-dataloader": "^0.1.6",

--- a/src/Prisma.ts
+++ b/src/Prisma.ts
@@ -18,13 +18,14 @@ export class Prisma extends Binding {
     secret,
     fragmentReplacements,
     debug,
+    disableCache,
   }: PrismaOptions) {
     if (!typeDefs) {
       throw new Error('No `typeDefs` provided when calling `new Prisma()`')
     }
 
     if (typeDefs.endsWith('.graphql')) {
-      typeDefs = getCachedTypeDefs(typeDefs)
+      typeDefs = getCachedTypeDefs(typeDefs, disableCache)
     }
 
     if (endpoint === undefined) {
@@ -44,7 +45,12 @@ export class Prisma extends Binding {
     const token = secret ? sign({}, secret!) : undefined
     const link = makePrismaLink({ endpoint: endpoint!, token, debug })
 
-    const remoteSchema = getCachedRemoteSchema(endpoint, typeDefs, sharedLink)
+    const remoteSchema = getCachedRemoteSchema(
+      endpoint,
+      typeDefs,
+      sharedLink,
+      disableCache,
+    )
 
     const before = () => {
       sharedLink.setInnerLink(link)

--- a/src/Prisma.ts
+++ b/src/Prisma.ts
@@ -60,6 +60,7 @@ export class Prisma extends Binding {
       schema: remoteSchema,
       fragmentReplacements,
       before,
+      disableCache,
     })
 
     this.exists = this.buildExists()

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -6,12 +6,20 @@ import { makeRemoteExecutableSchema } from 'graphql-tools'
 const typeDefsCache: { [schemaPath: string]: string } = {}
 const remoteSchemaCache: { [endpoint: string]: GraphQLSchema } = {}
 
-export function getCachedTypeDefs(schemaPath: string): string {
+export function getCachedTypeDefs(
+  schemaPath: string,
+  disableCache: boolean = false,
+): string {
   if (typeDefsCache[schemaPath]) {
     return typeDefsCache[schemaPath]
   }
 
   const schema = importSchema(schemaPath)
+
+  if (disableCache) {
+    return schema
+  }
+
   typeDefsCache[schemaPath] = schema
 
   return schema
@@ -21,6 +29,7 @@ export function getCachedRemoteSchema(
   endpoint: string,
   typeDefs: string,
   link: SharedLink,
+  disableCache: boolean = false,
 ): GraphQLSchema {
   if (remoteSchemaCache[endpoint]) {
     return remoteSchemaCache[endpoint]
@@ -30,6 +39,11 @@ export function getCachedRemoteSchema(
     link: link,
     schema: typeDefs,
   })
+
+  if (disableCache) {
+    return remoteSchema
+  }
+
   remoteSchemaCache[endpoint] = remoteSchema
 
   return remoteSchema

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -16,11 +16,9 @@ export function getCachedTypeDefs(
 
   const schema = importSchema(schemaPath)
 
-  if (disableCache) {
-    return schema
+  if (!disableCache) {
+    typeDefsCache[schemaPath] = schema
   }
-
-  typeDefsCache[schemaPath] = schema
 
   return schema
 }
@@ -40,11 +38,9 @@ export function getCachedRemoteSchema(
     schema: typeDefs,
   })
 
-  if (disableCache) {
-    return remoteSchema
+  if (!disableCache) {
+    remoteSchemaCache[endpoint] = remoteSchema
   }
-
-  remoteSchemaCache[endpoint] = remoteSchema
 
   return remoteSchema
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,6 +14,7 @@ export interface BasePrismaOptions {
   endpoint?: string
   secret?: string
   debug?: boolean
+  disableCache?: boolean
 }
 
 export interface PrismaOptions extends BasePrismaOptions {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2604,14 +2604,14 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.15.tgz#ffb703e1066e8a0eeaa4c8b80ba9253eeefbfb00"
   integrity sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==
 
-graphql-binding@2.4.1:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/graphql-binding/-/graphql-binding-2.4.1.tgz#5880b78670b5910b3589a6fa76441e9a7d8c289c"
-  integrity sha512-UHSVM2bfB4gGtwRcUXwejo2R825Rm8vnJGA6+IB+NquObXBdw6YvDSTIwgavsNM6I6qRlyl0CUaAf/r15YYqwQ==
+graphql-binding@2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/graphql-binding/-/graphql-binding-2.5.0.tgz#47eee13e622171bb337c2ce9bab6b4cecd5a76cc"
+  integrity sha512-DzZgPakNlAqELjO3M7F4YOSC4QBL3CTYGEH/NJdSvF/DqAGY7UrnCNVXGt+fR4yx+VYQVtd+kF2VgpZmIAahQg==
   dependencies:
     graphql "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0"
     graphql-import "^0.7.1"
-    graphql-tools "4.0.3"
+    graphql-tools "4.0.4"
     iterall "1.2.2"
     object-path-immutable "^3.0.0"
     resolve-cwd "^2.0.0"
@@ -2630,6 +2630,17 @@ graphql-tools@4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/graphql-tools/-/graphql-tools-4.0.3.tgz#23b5cb52c519212b1b2e4630a361464396ad264b"
   integrity sha512-NNZM0WSnVLX1zIMUxu7SjzLZ4prCp15N5L2T2ro02OVyydZ0fuCnZYRnx/yK9xjGWbZA0Q58yEO//Bv/psJWrg==
+  dependencies:
+    apollo-link "^1.2.3"
+    apollo-utilities "^1.0.1"
+    deprecated-decorator "^0.1.6"
+    iterall "^1.1.3"
+    uuid "^3.1.0"
+
+graphql-tools@4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/graphql-tools/-/graphql-tools-4.0.4.tgz#ca08a63454221fdde825fe45fbd315eb2a6d566b"
+  integrity sha512-chF12etTIGVVGy3fCTJ1ivJX2KB7OSG4c6UOJQuqOHCmBQwTyNgCDuejZKvpYxNZiEx7bwIjrodDgDe9RIkjlw==
   dependencies:
     apollo-link "^1.2.3"
     apollo-utilities "^1.0.1"


### PR DESCRIPTION
Although the caching system is useful if you use a limited amount of schemas, it exposes a severe memory leak for a project I'm working on, where I have to generate schemas on-the-fly, which are all cached multiple times. As I don't have the ability to control caching in this package, I've added a simple switch to disable adding items to the cache if wanted. This is completely opt-in and won't interfere with any current use cases.